### PR TITLE
Fix vehicle and player submenu

### DIFF
--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -283,6 +283,13 @@ namespace vMenuClient
 
             // Request server state from the server.
             TriggerServerEvent("vMenu:RequestServerState");
+            RegisterCommand("vmenu", new Action(OpenMenu), false);
+            RegisterKeyMapping("vmenu", "Open vMenu", "keyboard", "F6");
+        }
+
+        private void OpenMenu()
+        {
+            Menu.Visible = !Menu.Visible;
         }
 
 
@@ -516,11 +523,6 @@ namespace vMenuClient
                         MpPedCustomization.DisableBackButton = false;
                         MpPedCustomization.DontCloseMenus = false;
                     }
-                }
-
-                if (Game.IsControlJustPressed(0, Control.InteractionMenu))
-                {
-                    Menu.Visible = true;
                 }
 
                 if (Game.IsDisabledControlJustReleased(0, Control.PhoneCancel) && MpPedCustomization.DisableBackButton)

--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -283,8 +283,6 @@ namespace vMenuClient
 
             // Request server state from the server.
             TriggerServerEvent("vMenu:RequestServerState");
-            RegisterCommand("vmenu", new Action(OpenMenu), false);
-            RegisterKeyMapping("vmenu", "Open vMenu", "keyboard", "F6");
         }
 
         private void OpenMenu()
@@ -523,6 +521,11 @@ namespace vMenuClient
                         MpPedCustomization.DisableBackButton = false;
                         MpPedCustomization.DontCloseMenus = false;
                     }
+                }
+                
+                if (Game.IsControlJustPressed(0, Control.InteractionMenu))
+                {
+                    Menu.Visible = true;
                 }
 
                 if (Game.IsDisabledControlJustReleased(0, Control.PhoneCancel) && MpPedCustomization.DisableBackButton)

--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -618,7 +618,7 @@ namespace vMenuClient
 
             UIMenuItem playerSubmenuBtn = new UIMenuItem("Player Related Options", "Open this submenu for player related subcategories.");
             playerSubmenuBtn.SetRightLabel("→→→");
-            Menu.AddItem(playerSubmenuBtn);
+            AddMenu(Menu, PlayerSubmenu, playerSubmenuBtn);
 
             // Add the player options menu.
             if (IsAllowed(Permission.POMenu))
@@ -632,7 +632,7 @@ namespace vMenuClient
 
             UIMenuItem vehicleSubmenuBtn = new UIMenuItem("Vehicle Related Options", "Open this submenu for vehicle related subcategories.");
             vehicleSubmenuBtn.SetRightLabel("→→→");
-            Menu.AddItem(vehicleSubmenuBtn);
+            AddMenu(Menu, VehicleSubmenu, vehicleSubmenuBtn);
             // Add the vehicle options Menu.
             if (IsAllowed(Permission.VOMenu))
             {


### PR DESCRIPTION
Makes the "Player Related Options" and "Vehicle Related Options" actually switch to the submenu when clicked.