### PR TITLE
Fix saved vehicles displaying the wrong name

### DIFF
--- a/vMenu/menus/SavedVehicles.cs
+++ b/vMenu/menus/SavedVehicles.cs
@@ -325,7 +325,7 @@ namespace vMenuClient.menus
 
                     UIMenuItem savedVehicleBtn = new UIMenuItem(sv.Key.Substring(4), $"Manage this saved vehicle.")
                     {
-                        Label = $"({sv.Value.name}) →→→"
+                        Label = $"{sv.Key.Substring(4)} ({sv.Value.name}) →→→"
                     };
                     menu.AddItem(savedVehicleBtn);
 


### PR DESCRIPTION
Makes the vehicle button label  for a saved vehicle, display the name saved instead of just the model name