### PR TITLE
Fix menu history cleared when going to a saved vehicle

### DIFF
--- a/vMenu/menus/SavedVehicles.cs
+++ b/vMenu/menus/SavedVehicles.cs
@@ -252,8 +252,9 @@ namespace vMenuClient.menus
         /// Updates the selected vehicle.
         /// </summary>
         /// <param name="selectedItem"></param>
+        /// <param name="parentMenu"></param>
         /// <returns>A bool, true if successfull, false if unsuccessfull</returns>
-        private bool UpdateSelectedVehicleMenu(UIMenuItem selectedItem, UIMenu parentMenu = null)
+        private bool UpdateSelectedVehicleMenu(UIMenuItem selectedItem, UIMenu parentMenu)
         {
             if (!svMenuItems.ContainsKey(selectedItem))
             {
@@ -263,8 +264,7 @@ namespace vMenuClient.menus
             KeyValuePair<string, VehicleInfo> vehInfo = svMenuItems[selectedItem];
             selectedVehicleMenu.Subtitle = $"{vehInfo.Key.Substring(4)} ({vehInfo.Value.name})";
             currentlySelectedVehicle = vehInfo;
-            MenuHandler.CloseAndClearHistory();
-            selectedVehicleMenu.Visible = true;
+            parentMenu.SwitchTo(selectedVehicleMenu);
             return true;
         }
 


### PR DESCRIPTION
Previously the menu history was cleared when you clicked on a saved vehicle. This was because it was calling `MenuHandler.CloseAndClearHistory()` but this makes it instead call `parentMenu.SwitchTo`