### PR TITLE
Make open key and noclip use RegisterKeyMapping

### DIFF
--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -283,6 +283,45 @@ namespace vMenuClient
 
             // Request server state from the server.
             TriggerServerEvent("vMenu:RequestServerState");
+            
+            RegisterCommand("vmenu", new Action(OpenMenu), false);
+            RegisterKeyMapping("vmenu", "Open vMenu", "keyboard", GetSettingsString(Setting.vmenu_menu_toggle_key) ?? "M");
+            if (IsAllowed(Permission.NoClip))
+            {
+                RegisterCommand("vmenu_noclip", new Action(ToggleNoclip), false);
+                RegisterKeyMapping("vmenu_noclip", "Toggle NoClip", "keyboard", GetSettingsString(Setting.vmenu_noclip_toggle_key) ?? "F2");
+            }
+        }
+
+        private void OpenMenu()
+        {
+            Menu.Visible = !Menu.Visible;
+        }
+
+        private void ToggleNoclip()
+        {
+            if (!IsAllowed(Permission.NoClip))
+            {
+                return;
+            }
+
+            if (Game.PlayerPed.IsInVehicle())
+            {
+                Vehicle veh = GetVehicle();
+                if (veh != null && veh.Exists() && veh.Driver == Game.PlayerPed)
+                {
+                    NoClipEnabled = !NoClipEnabled;
+                }
+                else
+                {
+                    NoClipEnabled = false;
+                    Notify.Error("This vehicle does not exist (somehow) or you need to be the driver of this vehicle to enable noclip!");
+                }
+            }
+            else
+            {
+                NoClipEnabled = !NoClipEnabled;
+            }
         }
 
 
@@ -518,39 +557,10 @@ namespace vMenuClient
                     }
                 }
 
-                if (Game.IsControlJustPressed(0, Control.InteractionMenu))
-                {
-                    Menu.Visible = true;
-                }
-
                 if (Game.IsDisabledControlJustReleased(0, Control.PhoneCancel) && MpPedCustomization.DisableBackButton)
                 {
                     await Delay(0);
                     Notify.Alert("You must save your ped first before exiting, or click the ~r~Exit Without Saving~s~ button.");
-                }
-
-                if (Game.CurrentInputMode == InputMode.MouseAndKeyboard)
-                {
-                    if (Game.IsControlJustPressed(0, (Control)NoClipKey) && IsAllowed(Permission.NoClip) && UpdateOnscreenKeyboard() != 0)
-                    {
-                        if (Game.PlayerPed.IsInVehicle())
-                        {
-                            Vehicle veh = GetVehicle();
-                            if (veh != null && veh.Exists() && veh.Driver == Game.PlayerPed)
-                            {
-                                NoClipEnabled = !NoClipEnabled;
-                            }
-                            else
-                            {
-                                NoClipEnabled = false;
-                                Notify.Error("This vehicle does not exist (somehow) or you need to be the driver of this vehicle to enable noclip!");
-                            }
-                        }
-                        else
-                        {
-                            NoClipEnabled = !NoClipEnabled;
-                        }
-                    }
                 }
 
                 #endregion
@@ -616,7 +626,7 @@ namespace vMenuClient
 
             UIMenuItem playerSubmenuBtn = new UIMenuItem("Player Related Options", "Open this submenu for player related subcategories.");
             playerSubmenuBtn.SetRightLabel("→→→");
-            Menu.AddItem(playerSubmenuBtn);
+            AddMenu(Menu, PlayerSubmenu, playerSubmenuBtn);
 
             // Add the player options menu.
             if (IsAllowed(Permission.POMenu))
@@ -630,7 +640,7 @@ namespace vMenuClient
 
             UIMenuItem vehicleSubmenuBtn = new UIMenuItem("Vehicle Related Options", "Open this submenu for vehicle related subcategories.");
             vehicleSubmenuBtn.SetRightLabel("→→→");
-            Menu.AddItem(vehicleSubmenuBtn);
+            AddMenu(Menu, VehicleSubmenu, vehicleSubmenuBtn);
             // Add the vehicle options Menu.
             if (IsAllowed(Permission.VOMenu))
             {

--- a/vMenu/MainMenu.cs
+++ b/vMenu/MainMenu.cs
@@ -286,11 +286,10 @@ namespace vMenuClient
             
             RegisterCommand("vmenu", new Action(OpenMenu), false);
             RegisterKeyMapping("vmenu", "Open vMenu", "keyboard", GetSettingsString(Setting.vmenu_menu_toggle_key) ?? "M");
-            if (IsAllowed(Permission.NoClip))
-            {
-                RegisterCommand("vmenu_noclip", new Action(ToggleNoclip), false);
-                RegisterKeyMapping("vmenu_noclip", "Toggle NoClip", "keyboard", GetSettingsString(Setting.vmenu_noclip_toggle_key) ?? "F2");
-            }
+            
+            RegisterCommand("vmenu_noclip", new Action(ToggleNoclip), false);
+            RegisterKeyMapping("vmenu_noclip", "Toggle NoClip", "keyboard", GetSettingsString(Setting.vmenu_noclip_toggle_key) ?? "F2");
+            
         }
 
         private void OpenMenu()

--- a/vMenuServer/config/permissions.cfg
+++ b/vMenuServer/config/permissions.cfg
@@ -15,9 +15,9 @@ setr vmenu_menu_staff_only false
 # Disable setting stats like stamina, lung capacity, driving skills etc.
 setr vmenu_disable_player_stats_setup false
 
-# Any valid control ID can be used here.
-setr vmenu_menu_toggle_key 244
-setr vmenu_noclip_toggle_key 289
+# Any valid control ID can be used here. These can be changed by the player in their keybinding settings but these set the default values for new players.
+setr vmenu_menu_toggle_key M
+setr vmenu_noclip_toggle_key F2
 
 # Keeps spawned vehicles from de-spawning if 'replace previous vehicle' is disabled.
 setr vmenu_keep_spawned_vehicles_persistent false


### PR DESCRIPTION
This PR makes the menu open key and noclip toggle key use [RegisterKeyMapping](https://docs.fivem.net/natives/?_0xD7664FD1) so they can be changeable for each user. Defaults for new players are based on what is set in the server they first joined 